### PR TITLE
adjusted for changes in light level for minecraft 1.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
 
     <groupId>org.kowboy.bukkit</groupId>
     <artifactId>bukkit-light-level</artifactId>
-    <version>1.1</version>
+    <version>1.2</version>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.4-R0.1-SNAPSHOT</version>
+            <version>1.18-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/kowboy/bukkit/light/LightLevelTask.java
+++ b/src/main/java/org/kowboy/bukkit/light/LightLevelTask.java
@@ -106,9 +106,7 @@ public class LightLevelTask extends BukkitRunnable {
     }
 
     private Color getColor(byte lightLevel) {
-        if (lightLevel >= 12) return Color.LIME;
-        if (lightLevel >= 10) return Color.GREEN;
-        if (lightLevel >= 8)  return Color.YELLOW;
+        if (lightLevel > 0) return Color.GREEN;
         return Color.RED;
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: BukkitLightLevel
-version: 1.1
-api-version: 1.15
+version: 1.2
+api-version: 1.18
 author: Craig McDaniel
 website: https://github.com/cpmcdaniel/bukkit-light-level
 main: org.kowboy.bukkit.light.LightLevelPlugin


### PR DESCRIPTION
Hello!
I took the liberty to adjust your plugin to the changes made in minecraft 1.18.
From minecraft 1.18 release notes: 

> Hostile mobs spawn only in areas where the light level is equal to 0.

I did not make it backwards compatible, though..
Also I took the liberty of updating spigotmc and java version.

It's tested on my own home server.